### PR TITLE
feat(aenyrathia.wiki): add get route for viewing wiki articles

### DIFF
--- a/src/cli/render.rs
+++ b/src/cli/render.rs
@@ -1,4 +1,5 @@
 use clap::Args;
+use log::info;
 use markdown::to_html;
 use std::fs;
 use std::io;
@@ -12,7 +13,7 @@ pub struct RenderArgs {
 impl RenderArgs {
     pub fn run(&self) -> io::Result<()> {
         let content = fs::read_to_string(&self.path)?;
-        println!("{}", to_html(&content));
+        info!("{}", to_html(&content));
         Ok(())
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -1,6 +1,14 @@
+use askama::Template;
 use axum::Router;
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::Html;
+use axum::routing::get;
 use clap::Args;
 use log::info;
+use log::warn;
+use markdown::to_html;
+use std::fs;
 
 #[derive(Args)]
 pub struct ServeArgs {}
@@ -10,6 +18,42 @@ impl ServeArgs {
     pub async fn run() {
         let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
         info!("Starting axum router and listening on 0.0.0.0:3000");
-        axum::serve(listener, Router::new()).await.unwrap();
+        axum::serve(
+            listener,
+            Router::new().route("/wiki/{*article_path}", get(wiki_page)),
+        )
+        .await
+        .unwrap();
     }
+}
+
+#[derive(Template)]
+#[template(path = "article.html")]
+struct WikiArticleTemplate {
+    content: String,
+}
+
+async fn wiki_page(Path(article_path): Path<String>) -> Result<Html<String>, StatusCode> {
+    // note: article_path resolves without preceding slash
+    let wiki_directory = "wiki/".to_string();
+    let file_path = wiki_directory + &article_path + ".md";
+    fs::read_to_string(&file_path).map_or_else(
+        |e| {
+            warn!("Couldn't read {file_path} to string: {e}");
+            Err(StatusCode::NOT_FOUND)
+        },
+        |file_content| {
+            WikiArticleTemplate {
+                content: to_html(&file_content),
+            }
+            .render()
+            .map_or_else(
+                |e| {
+                    warn!("Error rendering template for {file_path}: {e}");
+                    Err(StatusCode::INTERNAL_SERVER_ERROR)
+                },
+                |rendered| Ok(Html(rendered)),
+            )
+        },
+    )
 }

--- a/templates/article.html
+++ b/templates/article.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    {{ content|safe }}
+  </body>
+</html>


### PR DESCRIPTION
works:
<img width="2366" height="532" alt="image" src="https://github.com/user-attachments/assets/01e3e07a-5ba8-4b57-b26c-cc6ac6e69ace" />

- sprint: get route `/wiki/<path>` renders markdown as html
    - `markdown-rs` to parse to html
    - `axum` to provide routing
    - map the url path to the wiki directory
    - [x] step 1: install axum and tokio (5 mins)
    - [x] step 2: rewrite main.rs to serve axum hello world route (15 mins) (actual 15 mins)
        - 9.30am 
        - `warning: multiple versions for dependency `windows-sys`: 0.60.2, 0.61.2`
        - git stashed work on step 2 to investigate
        - [If a specific duplicate crate is acceptable, add it to the allowed_duplicate_crates configuration option.](https://rust-lang.github.io/rust-clippy/master/index.html#multiple_crate_versions)
        - how to add that option? https://doc.rust-lang.org/clippy/configuration.html
            - `clippy.toml` -> current dir, or `$CLIPPY_CONF_DIR` or `$CARGO_MANIFEST_DIR`
                - basic `<variable> = <value>` mapping e.g. `allowed-duplicate-crates = [windows-sys]`
                - full list: https://doc.rust-lang.org/clippy/lint_configuration.html
            - add attributes to code
            - allow/deny entire lints
        - finished 9.46am
    - [x] step 3: add `GET /wiki/<path>` route (5 mins) actual 46mins
        - start 9.45am
        - how to add routes to axum?
            - axum apps are built by routing between handlers
            - axum handlers: async fn, >= 0 extractors as args, returns something that can be converted into a response
            - extractors: arguments for handler fns, implements FromRequest or FromRequestParts, used for path, query params, request body, headers, whole request, request extensions
            - responses: ?
        - GET `/wiki/<path>`:
            - handler: `async fn wiki_page(axum::extract::Path(page_path): axum::extract::Path<String>) {}`
                - return `page_path`
            - route: `.route("/wiki/{page_path}", axum::routing::get(wiki_page)`
        - works at 10.07am
        - bug: `wiki/a/b` doesnt work
            - why? probably axum takes precedence
            - if the url has `/`, it takes it as a path instead of a string
            - investigate Path struct - https://docs.rs/axum/latest/axum/extract/struct.Path.html
                - use `Option<Path<T>>` to allow two routes, one with parameters that deserialise to `T`, and another with no parameters at all, to use the same handler
        - stopped for chess break at 10.14am 34min
        - from 11.25 to 11.37 looked into different extractors for the handler, ManagedPath, Path, and http::Uri all dont work (404) 12 min
        - from 12.06 to ?
        - likely the router is the one that needs to be configured to accept subpaths
        - https://docs.rs/axum/latest/axum/struct.Router.html#method.route
        - axum::Router.route()
            - each segment in path can be static, a capture, or a wildcard
            - wildcards will match all segments e.g. `/(*key)` will capture all segments
        - aka our route call needs to be changed to `/wiki/{*page_path}`
        - done at 12.14 8 min sesh
    - [x] step 4: make the get route map the path given to the wiki directory (30 mins) start 12.15 done in 20 mins + display the parsed html in the browser (est. 30 mins)
        - store wiki directory in local variable
        - `Markdown::from_path(wiki_directory + article_path).to_html`
        - 12.22pm, realised we need to return 404 for non existent files - how for axum?
            - the handler must return `Result<T, axum::http::StatusCode`
            - the handler must return `Err(StatusCode::NOT_FOUND)`to give a 404
            - match on `Markdown::from_path(...)`, `Ok(markdown) -> Ok(markdown.as_html())` and `Err(_) => Err(StatusCode::NOT_FOUND)`
            - rust `map_or_else` usage: `map_or_else(<closure for Err>, <closure for Ok>)`
        - done at 12.35
    - brief detour to make the app serve under `serve` subcommand, learnt that empty clap args should just be represented by empty struct until 1.09pm
    - [x] step 5: init askama and write hello world (10 mins)
        - started at 1.15pm
        - https://askama.readthedocs.io/en/stable/
        - askama works via the `#[derive(Template)]` macro on structs which represent the fields passed in as variables into the template
        - use `[template(path = "hello.html")]` to get a template relative to the templates dir in the crate root
        - `struct HelloTemplate<`a>` -> why need lifetime?
        - `name: &'a str,` -> ?
        - instantiate the struct with values
        - render it with `render().unwrap()`
        - now its not quite working cos the render method returns a result
        - why would it fail?
        - decide what to do based on the failure
        - merge at 1.34pm
    - [x] step 6: use askama to wrap the get `/wiki/<path>` in a template (est 5 mins) started 1.35pm ended 1.51pm total 15mins
    - todo:
        - figure out how to get browser to recognise the route as valid html
            - https://woile.dev/posts/web-app-with-template-in-rust/
            - https://docs.rs/axum/latest/axum/response/struct.Html.html
            - axum::response::Html actuall gets `Content-Type: text/html` right, but the markdown parsed to html just displays raw
        - figure out styling
        - figure out breadcrumbs
