### PR TITLE
feat: set logged in user to git commit author

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -16,6 +16,12 @@ fn path_editable<P: AsRef<Path>>(path: P) -> bool {
     path.is_file() || path.parent().is_some_and(std::path::Path::is_dir)
 }
 
+/// Author information for a commit.
+pub struct Author {
+    pub name: String,
+    pub email: String,
+}
+
 /// Lightweight handle for cloning, reading, and writing to a remote git repository.
 pub struct GitRemote {
     /// Keep tempdir alive so the cloned repo is not deleted.
@@ -104,6 +110,7 @@ impl GitRemote {
         relative_path: &str,
         content: &str,
         branch_name: Option<&str>,
+        author: Option<&Author>,
     ) -> Result<(), ()> {
         let repo = Repository::open(&self.repo_directory).map_err(|_| ())?;
         let branch_name = branch_name.unwrap_or("prime");
@@ -160,10 +167,13 @@ impl GitRemote {
             .find_reference(&format!("refs/heads/{branch_name}"))
             .map_err(|_| ())?;
         let parent_commit = parent_reference.peel_to_commit().map_err(|_| ())?;
-        let signature = repo.signature().unwrap_or_else(|_| {
-            Signature::now("aenyrathia.wiki", "git@aenyrathia.wiki")
-                .expect("Failed to create fallback signature")
-        });
+        let signature = author
+            .and_then(|author| Signature::now(&author.name, &author.email).ok())
+            .or_else(|| repo.signature().ok())
+            .unwrap_or_else(|| {
+                Signature::now("aenyrathia.wiki", "git@aenyrathia.wiki")
+                    .expect("Failed to create fallback signature")
+            });
         repo.commit(
             Some(&format!("refs/heads/{branch_name}")),
             &signature,

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -116,6 +116,7 @@ pub async fn login_post(
         .is_ok()
     {
         cookies.add(Cookie::new("full_name", result.full_name));
+        cookies.add(Cookie::new("email", email));
         Ok(Redirect::to("/"))
     } else {
         Err(StatusCode::UNAUTHORIZED)

--- a/src/routes/wiki.rs
+++ b/src/routes/wiki.rs
@@ -102,7 +102,7 @@ pub async fn article_post(
         let content = normalise_newlines(&form.markdown);
         match state
             .remote
-            .write_file(&relative_path, &content, Some(&branch_name))
+            .write_file(&relative_path, &content, Some(&branch_name), None)
         {
             Ok(()) => Ok(Redirect::to(&redirect_path)),
             Err(()) => Err(StatusCode::INTERNAL_SERVER_ERROR),

--- a/src/routes/wiki.rs
+++ b/src/routes/wiki.rs
@@ -1,5 +1,6 @@
 use crate::app::state::AppState;
 use crate::formatting::{normalise_newlines, resolve_article_path, resolve_branch_name};
+use crate::git::Author;
 use askama::Template;
 use axum::Router;
 use axum::extract::Form;
@@ -100,10 +101,16 @@ pub async fn article_post(
         let relative_path = resolve_article_path(article_path);
         let branch_name = resolve_branch_name(Some(true), Some(&full_name.value().to_string()));
         let content = normalise_newlines(&form.markdown);
-        match state
-            .remote
-            .write_file(&relative_path, &content, Some(&branch_name), None)
-        {
+        let author = cookies.get("email").map(|email| Author {
+            name: full_name.value().to_string(),
+            email: email.value().to_string(),
+        });
+        match state.remote.write_file(
+            &relative_path,
+            &content,
+            Some(&branch_name),
+            author.as_ref(),
+        ) {
             Ok(()) => Ok(Redirect::to(&redirect_path)),
             Err(()) => Err(StatusCode::INTERNAL_SERVER_ERROR),
         }


### PR DESCRIPTION
Stored the email in a cookie to pass to `GitRemote::write_file` as the commit author.
